### PR TITLE
Fix crash in case no locale is set

### DIFF
--- a/gogrepoc.py
+++ b/gogrepoc.py
@@ -197,7 +197,8 @@ if not (sysOS in VALID_OS_TYPES):
     sysOS = 'linux'
 DEFAULT_OS_LIST = [sysOS]
 sysLang,_ = locale.getdefaultlocale()
-sysLang = sysLang[:2]
+if (sysLang is not None):
+    sysLang = sysLang[:2]
 if not (sysLang in VALID_LANG_TYPES):
     sysLang = 'en'
 DEFAULT_LANG_LIST = [sysLang]


### PR DESCRIPTION
On my NAS I get this crash:

Updating GOG library
Traceback (most recent call last):
  File "./gogrepoc.py", line 200, in <module>
    sysLang = sysLang[:2]
TypeError: 'NoneType' object is not subscriptable