### PR TITLE
Modified argument action

### DIFF
--- a/gogrepoc.py
+++ b/gogrepoc.py
@@ -943,10 +943,10 @@ def process_argv(argv):
     g1.add_argument('-resumemode',action="store",choices=['noresume','resume','onlyresume'],default='resume',help="how to handle resuming if necessary")
     g1.add_argument('-strictverify',action="store_true",help="clear previously verified unless md5 match")
     g2 = g1.add_mutually_exclusive_group()
-    g2.add_argument('-os', action='store', help='operating system(s)', nargs='*', default=[])
+    g2.add_argument('-os', action='extend', help='operating system(s)', nargs='*', default=[])
     g2.add_argument('-skipos', action='store', help='skip operating system(s)', nargs='*', default=[])  
     g3 = g1.add_mutually_exclusive_group()
-    g3.add_argument('-lang', action='store', help='game language(s)', nargs='*', default=[])
+    g3.add_argument('-lang', action='extend', help='game language(s)', nargs='*', default=[])
     g3.add_argument('-skiplang', action='store', help='skip game language(s)', nargs='*', default=[])      
     g1.add_argument('-skiphidden',action='store_true',help='skip games marked as hidden')
     g1.add_argument('-installers', action='store', choices = ['standalone','both'], default = 'standalone',  help='GOG Installer type to use: standalone or both galaxy and standalone. Default: standalone (Deprecated)')    
@@ -984,9 +984,9 @@ def process_argv(argv):
                     help='limit downloads to this many MB (approximately)', default=None)  # sleep in hr
     g4 = g1.add_mutually_exclusive_group()  # below are mutually exclusive    
     g4.add_argument('-skipos', action='store', help='skip downloading game files for operating system(s)', nargs='*', default=[])  
-    g4.add_argument('-os', action='store', help='download game files only for operating system(s)', nargs='*', default=[]) 
+    g4.add_argument('-os', action='extend', help='download game files only for operating system(s)', nargs='*', default=[]) 
     g5 = g1.add_mutually_exclusive_group()  # below are mutually exclusive    
-    g5.add_argument('-lang', action='store', help='download game files only for language(s)', nargs='*', default=[])    
+    g5.add_argument('-lang', action='extend', help='download game files only for language(s)', nargs='*', default=[])    
     g5.add_argument('-skiplang', action='store', help='skip downloading game files for language(s)', nargs='*', default=[])  
     g1.add_argument('-nolog', action='store_true', help = 'doesn\'t writes log file gogrepo.log')
     g1.add_argument('-debug', action='store_true', help = "Includes debug messages")


### PR DESCRIPTION
I'm not an expert in python, but someone might find it useful:
In Linux there is an issue with argument format `-lang en ru` and `-os windows mac linux` and the script fails to download any language except default and any OS if the list is bigger than single value With this change one can execute the script with multiple `-os mac -os linux -os windows` arguments and it will work on Linux
Unfortunately this only works in python 3.9 AFAIK
kudos to @nshmakov for the hint